### PR TITLE
feat(conference): auto-show invite dialog when moderator joins alone

### DIFF
--- a/react/features/conference/components/web/Conference.tsx
+++ b/react/features/conference/components/web/Conference.tsx
@@ -6,10 +6,12 @@ import { connect as reactReduxConnect, useDispatch, useSelector, useStore } from
 // @ts-expect-error
 import VideoLayout from '../../../../../modules/UI/videolayout/VideoLayout';
 import { IReduxState, IStore } from '../../../app/types';
+import { CONFERENCE_JOINED } from '../../../base/conference/actionTypes';
 import { getConferenceNameForTitle } from '../../../base/conference/functions';
 import { hangup } from '../../../base/connection/actions.web';
 import { isMobileBrowser } from '../../../base/environment/utils';
 import { translate } from '../../../base/i18n/functions';
+import MiddlewareRegistry from '../../../base/redux/MiddlewareRegistry';
 import { setColorAlpha } from '../../../base/util/helpers';
 import { openChat, setFocusedTab } from '../../../chat/actions.web';
 import Chat from '../../../chat/components/web/Chat';
@@ -18,6 +20,7 @@ import { isFileUploadingEnabled, processFiles } from '../../../file-sharing/func
 import MainFilmstrip from '../../../filmstrip/components/web/MainFilmstrip';
 import ScreenshareFilmstrip from '../../../filmstrip/components/web/ScreenshareFilmstrip';
 import StageFilmstrip from '../../../filmstrip/components/web/StageFilmstrip';
+import { beginAddPeople } from '../../../invite/actions.any';
 import CalleeInfoContainer from '../../../invite/components/callee-info/CalleeInfoContainer';
 import LargeVideo from '../../../large-video/components/LargeVideo.web';
 import LobbyScreen from '../../../lobby/components/web/LobbyScreen';
@@ -45,6 +48,24 @@ import {
 
 import ConferenceInfo from './ConferenceInfo';
 import { default as Notice } from './Notice';
+
+MiddlewareRegistry.register(store => next => action => {
+    switch (action.type) {
+    case CONFERENCE_JOINED: {
+        const state = store.getState();
+        const participants = state['features/base/participants'];
+
+        if (participants.local?.role === 'moderator' && !Boolean(participants.remote.size)) {
+            store.dispatch(beginAddPeople());
+        }
+
+        break;
+    }
+    }
+
+    return next(action);
+});
+
 
 /**
  * DOM events for when full screen mode has changed. Different browsers need

--- a/react/features/conference/components/web/Conference.tsx
+++ b/react/features/conference/components/web/Conference.tsx
@@ -55,7 +55,7 @@ MiddlewareRegistry.register(store => next => action => {
         const state = store.getState();
         const participants = state['features/base/participants'];
 
-        if (participants.local?.role === 'moderator' && !Boolean(participants.remote.size)) {
+        if (!Boolean(participants.remote.size)) {
             store.dispatch(beginAddPeople());
         }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

Automatically show invite dialog when user is a moderator and joins an empty meeting